### PR TITLE
Create mixer by &[Channel] instead of Vec<Channel>

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -20,7 +20,7 @@ where
     T: Clone + Default + From<u8> + ?Sized + Any,
 {
     // Downmix from 5.1 to stereo.
-    let input_channels = vec![
+    let input_channels = [
         Channel::FrontLeft,
         Channel::FrontRight,
         Channel::FrontCenter,
@@ -28,8 +28,8 @@ where
         Channel::BackLeft,
         Channel::BackRight,
     ];
-    let output_channels = vec![Channel::FrontLeft, Channel::FrontRight];
-    mix::<T>(input_channels, output_channels, frames);
+    let output_channels = [Channel::FrontLeft, Channel::FrontRight];
+    mix::<T>(&input_channels, &output_channels, frames);
 }
 
 fn upmix<T>(frames: usize)
@@ -37,12 +37,12 @@ where
     T: Clone + Default + From<u8> + ?Sized + Any,
 {
     // upmix from mono to stereo.
-    let input_channels = vec![Channel::FrontCenter];
-    let output_channels = vec![Channel::FrontLeft, Channel::FrontRight];
-    mix::<T>(input_channels, output_channels, frames);
+    let input_channels = [Channel::FrontCenter];
+    let output_channels = [Channel::FrontLeft, Channel::FrontRight];
+    mix::<T>(&input_channels, &output_channels, frames);
 }
 
-fn mix<T>(input_channels: Vec<Channel>, output_channels: Vec<Channel>, frames: usize)
+fn mix<T>(input_channels: &[Channel], output_channels: &[Channel], frames: usize)
 where
     T: Clone + Default + From<u8> + ?Sized + Any,
 {

--- a/src/coefficient.rs
+++ b/src/coefficient.rs
@@ -20,10 +20,10 @@ struct ChannelLayout {
 }
 
 impl ChannelLayout {
-    fn new(channels: Vec<Channel>) -> Result<Self, Error> {
-        let channel_map = Self::get_channel_map(&channels)?;
+    fn new(channels: &[Channel]) -> Result<Self, Error> {
+        let channel_map = Self::get_channel_map(channels)?;
         Ok(Self {
-            channels,
+            channels: channels.to_vec(),
             channel_map,
         })
     }
@@ -79,7 +79,7 @@ where
     //
     // In math, the in_audio and out_audio should be a 2D-matrix with several rows containing only
     // one column. However, the in_audio and out_audio are passed by 1-D matrix here for convenience.
-    pub fn create(input_channels: Vec<Channel>, output_channels: Vec<Channel>) -> Self {
+    pub fn create(input_channels: &[Channel], output_channels: &[Channel]) -> Self {
         let input_layout = ChannelLayout::new(input_channels).expect("Invalid input layout");
         let output_layout = ChannelLayout::new(output_channels).expect("Invalid output layout");
 
@@ -498,7 +498,7 @@ where
     T: MixingCoefficient,
     T::Coef: Copy + Debug,
 {
-    let input_channels = vec![
+    let input_channels = [
         Channel::Silence,
         Channel::FrontRight,
         Channel::FrontLeft,
@@ -507,8 +507,8 @@ where
         Channel::BackCenter,
         Channel::LowFrequency,
     ];
-    let output_channels = vec![Channel::Silence, Channel::FrontRight, Channel::FrontLeft];
-    let coefficient = Coefficient::<T>::create(input_channels.clone(), output_channels.clone());
+    let output_channels = [Channel::Silence, Channel::FrontRight, Channel::FrontLeft];
+    let coefficient = Coefficient::<T>::create(&input_channels, &output_channels);
     println!(
         "{:?} = {:?} * {:?}",
         output_channels, coefficient.matrix, input_channels
@@ -531,13 +531,13 @@ where
     T: MixingCoefficient,
     T::Coef: Copy,
 {
-    let input_channels = vec![
+    let input_channels = [
         Channel::FrontLeft,
         Channel::Silence,
         Channel::FrontLeft,
         Channel::FrontCenter,
     ];
-    let output_channels = vec![
+    let output_channels = [
         Channel::Silence,
         Channel::FrontRight,
         Channel::FrontLeft,
@@ -545,7 +545,7 @@ where
         Channel::FrontCenter,
         Channel::BackCenter,
     ];
-    let _ = Coefficient::<T>::create(input_channels, output_channels);
+    let _ = Coefficient::<T>::create(&input_channels, &output_channels);
 }
 
 #[test]
@@ -566,13 +566,13 @@ where
     T: MixingCoefficient,
     T::Coef: Copy,
 {
-    let input_channels = vec![
+    let input_channels = [
         Channel::FrontLeft,
         Channel::Silence,
         Channel::FrontRight,
         Channel::FrontCenter,
     ];
-    let output_channels = vec![
+    let output_channels = [
         Channel::Silence,
         Channel::FrontRight,
         Channel::FrontLeft,
@@ -580,7 +580,7 @@ where
         Channel::FrontCenter,
         Channel::BackCenter,
     ];
-    let _ = Coefficient::<T>::create(input_channels, output_channels);
+    let _ = Coefficient::<T>::create(&input_channels, &output_channels);
 }
 
 #[test]
@@ -635,13 +635,13 @@ where
             .collect()
     }
 
-    let input_channels = vec![
+    let input_channels = [
         Channel::FrontLeft,
         Channel::Silence,
         Channel::FrontRight,
         Channel::FrontCenter,
     ];
-    let output_channels = vec![
+    let output_channels = [
         Channel::Silence,
         Channel::FrontLeft,
         Channel::Silence,
@@ -650,7 +650,7 @@ where
     ];
 
     // Get a redirect matrix since the output layout is asymmetric.
-    let coefficient = Coefficient::<T>::create(input_channels.clone(), output_channels.clone());
+    let coefficient = Coefficient::<T>::create(&input_channels, &output_channels);
 
     let expected = compute_redirect_matrix::<T>(&input_channels, &output_channels);
     assert_eq!(coefficient.matrix, expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ where
     T: Copy + Debug + MixingCoefficient,
     T::Coef: AddAssign + Copy + Debug + Default + Mul<T::Coef, Output = T::Coef>,
 {
-    pub fn new(input_channels: Vec<Channel>, output_channels: Vec<Channel>) -> Self {
+    pub fn new(input_channels: &[Channel], output_channels: &[Channel]) -> Self {
         Self {
             coefficient: Coefficient::create(input_channels, output_channels),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,13 @@ use audio_mixer::{Channel, Mixer};
 
 fn main() {
     // f32
-    let input_channels = vec![
+    let input_channels = [
         Channel::FrontLeft,
         Channel::Silence,
         Channel::FrontRight,
         Channel::FrontCenter,
     ];
-    let output_channels = vec![Channel::FrontLeft, Channel::FrontRight];
+    let output_channels = [Channel::FrontLeft, Channel::FrontRight];
 
     let mut input_buffer = vec![0.0; input_channels.len()];
     for (i, data) in input_buffer.iter_mut().enumerate() {
@@ -17,13 +17,13 @@ fn main() {
     }
     let mut output_buffer = vec![0.0; output_channels.len()];
 
-    let mixer = Mixer::new(input_channels, output_channels);
+    let mixer = Mixer::new(&input_channels, &output_channels);
 
     mixer.mix(&input_buffer.as_slice(), &mut output_buffer.as_mut_slice());
     println!("{:?} is mixed to {:?}", input_buffer, output_buffer);
 
     // i16
-    let input_channels = vec![
+    let input_channels = [
         Channel::FrontLeft,
         Channel::Silence,
         Channel::FrontRight,
@@ -35,7 +35,7 @@ fn main() {
         Channel::BackCenter,
         Channel::BackRight,
     ];
-    let output_channels = vec![Channel::Silence, Channel::FrontRight, Channel::FrontLeft];
+    let output_channels = [Channel::Silence, Channel::FrontRight, Channel::FrontLeft];
 
     let mut input_buffer = vec![0; input_channels.len()];
     for (i, data) in input_buffer.iter_mut().enumerate() {
@@ -43,7 +43,7 @@ fn main() {
     }
     let mut output_buffer = vec![0; output_channels.len()];
 
-    let mixer = Mixer::new(input_channels, output_channels);
+    let mixer = Mixer::new(&input_channels, &output_channels);
 
     mixer.mix(&input_buffer.as_slice(), &mut output_buffer.as_mut_slice());
     println!("{:?} is mixed to {:?}", input_buffer, output_buffer);


### PR DESCRIPTION
Using `&[Channel]` to create Mixer can free the caller from managing
the `Vec<Channel>` by the caller itself. As a result, the caller can use
the slice by its preference, whether it's from an array or a `Vec`, and
avoid calling `Vec<Channel>::clone()`. The Mixer should be responsible
to manage its own `Vec<Channel>` inside its data structure.