### PR TITLE
Fix floating-point comparison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bitflags = "1.2"
 
 [dev-dependencies]
 criterion = "0.3"
+float-cmp = "0.6"
 
 [[bench]]
 name = "benchmark"

--- a/src/coefficient.rs
+++ b/src/coefficient.rs
@@ -723,6 +723,8 @@ mod test {
 
     #[test]
     fn test_normalize() {
+        use float_cmp::approx_eq;
+
         let m = vec![
             vec![1.0_f64, 2.0_f64, 3.0_f64],
             vec![4.0_f64, 6.0_f64, 10.0_f64],
@@ -747,6 +749,6 @@ mod test {
             max_row_sum = max_row_sum.max(row.iter().sum());
             assert!(row.iter().sum::<f64>() <= smaller_max);
         }
-        assert!((smaller_max - max_row_sum).abs() < std::f64::EPSILON);
+        assert!(approx_eq!(f64, smaller_max, max_row_sum));
     }
 }


### PR DESCRIPTION
According to https://floating-point-gui.de/errors/comparison/, check the
equality of the `a` and `b` by `abs(a-b) < epsilon`, where `a` and `b`
are both floating-point variables, might not work. We should use an
existing floating-point comparison crate on crates.io to do that job.