### PR TITLE
Revise test settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,8 @@ before_script:
   - cargo --version
   - sh install_rustfmt_clippy.sh
 script:
-  - cargo fmt --all -- --check
-  - cargo clippy --all-targets --all-features -- -D warnings
   - cargo build --verbose --all
-  - cargo test --verbose --all
+  - sh run_tests.sh
 jobs:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ env:
 before_script:
   - rustc --version
   - cargo --version
-  - rustup component add rustfmt
-  - rustup component add clippy
+  - sh install_rustfmt_clippy.sh
 script:
   - cargo fmt --all -- --check
   - cargo clippy --all-targets --all-features -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
 script:
   - cargo build --verbose --all
   - sh run_tests.sh
+  - sh run_sanitizers.sh
 jobs:
   allow_failures:
     - rust: nightly

--- a/install_rustfmt_clippy.sh
+++ b/install_rustfmt_clippy.sh
@@ -1,0 +1,17 @@
+# https://github.com/rust-lang/rustup-components-history/blob/master/README.md
+# https://github.com/rust-lang/rust-clippy/blob/27acea0a1baac6cf3ac6debfdbce04f91e15d772/.travis.yml#L40-L46
+if ! rustup component add rustfmt; then
+    TARGET=$(rustc -Vv | awk '/host/{print $2}')
+    NIGHTLY=$(curl -s "https://rust-lang.github.io/rustup-components-history/${TARGET}/rustfmt")
+    curl -sSL "https://static.rust-lang.org/dist/${NIGHTLY}/rustfmt-nightly-${TARGET}.tar.xz" | \
+    tar -xJf - --strip-components=3 -C ~/.cargo/bin
+    rm -rf ~/.cargo/bin/doc
+fi
+
+if ! rustup component add clippy; then
+    TARGET=$(rustc -Vv | awk '/host/{print $2}')
+    NIGHTLY=$(curl -s "https://rust-lang.github.io/rustup-components-history/${TARGET}/clippy")
+    rustup default nightly-${NIGHTLY}
+    rustup component add rustfmt
+    rustup component add clippy
+fi

--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -1,0 +1,40 @@
+# The option `Z` is only accepted on the nightly compiler
+# so changing to nightly toolchain by `rustup default nightly` is required.
+
+# See: https://github.com/rust-lang/rust/issues/39699 for more sanitizer support.
+
+toolchain=$(rustup default)
+echo "\nUse Rust toolchain: $toolchain"
+
+NIGHTLY_PREFIX="nightly-"
+if [ ! -z "${toolchain##$NIGHTLY_PREFIX*}" ]; then
+  echo "The sanitizer is only available on Rust Nightly only. Skip."
+  exit
+fi
+
+# Display verbose backtrace for debugging if backtrace is unset
+if [ -z "${RUST_BACKTRACE}" ]; then
+  export RUST_BACKTRACE=1
+fi
+echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
+
+# {Address, Thread}Sanitizer cannot build with `criterion` crate, so `criterion` will be removed
+# from the `Cargo.toml` temporarily during the sanitizer tests.
+ORIGINAL_MANIFEST="Cargo_ori.toml"
+mv Cargo.toml $ORIGINAL_MANIFEST
+# Delete lines that contain a `criterion` from Cargo.toml.
+sed '/criterion/d' $ORIGINAL_MANIFEST > Cargo.toml
+
+sanitizers=("address" "leak" "memory" "thread")
+for san in "${sanitizers[@]}"
+do
+  San="$(tr '[:lower:]' '[:upper:]' <<< ${san:0:1})${san:1}"
+  echo "\n\nRun ${San}Sanitizer\n------------------------------"
+  if [ $san = "leak" ]; then
+    echo "Skip the test that panics. Leaking memory when the program drops out abnormally is ok."
+    options="-- --Z unstable-options --exclude-should-panic"
+  fi
+  RUSTFLAGS="-Z sanitizer=${san}" cargo test $options
+done
+
+mv $ORIGINAL_MANIFEST Cargo.toml

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,14 @@
+# Display verbose backtrace for debugging if backtrace is unset
+if [ -z "${RUST_BACKTRACE}" ]; then
+  export RUST_BACKTRACE=1
+fi
+echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
+
+# Format check
+cargo fmt --all -- --check
+
+# Lints check
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Regular Tests
+cargo test --verbose --all


### PR DESCRIPTION
- Download the latest available *Rust nightly* for running both `cargo fmt` abd `cargo clippy`
- Create a test script that can be used both locally and on the *Travis CI* server
    - As a result, it's easier to make sure the local test results meet the test requirements running on the server
- Run the tests by the available *Rust sanitizers* to hunt memory issues.
    - The test that panics won't be executed while running *MemorySanitizer* since memory-leak is natural if the program drops out abnormally in the middle